### PR TITLE
Correct j2119 spec on optional Cause/Reason fields in Fail states

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -25,8 +25,8 @@ A Pass State MAY have a field named "Result".
 A Fail State MUST NOT have a field named "InputPath".
 A Fail State MUST NOT have a field named "ResultPath".
 A Fail State MUST NOT have a field named "OutputPath".
-A Fail State MUST have a string field named "Cause".
-A Fail State MUST have a string field named "Error".
+A Fail State MAY have a string field named "Cause".
+A Fail State MAY have a string field named "Error".
 Each of a Task State and a Parallel State MAY have an object-array field named "Retry"; each element is a "Retrier".
 A Task State MUST have a URI field named "Resource".
 A Task State MAY have a positive-integer field named "TimeoutSeconds" whose value MUST be less than 99999999.

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -1,0 +1,29 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the LICENSE.txt file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#!/usr/bin/env ruby
+
+$:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
+require 'json'
+require 'statelint'
+
+describe StateMachineLint do
+
+  it 'should allow Fail states to omit optional Cause/Error fields' do
+    j = File.read "test/minimal-fail-state.json"
+    j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+end

--- a/test/minimal-fail-state.json
+++ b/test/minimal-fail-state.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "A Task",
+  "States": {
+    "A Task": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:us-west-2:42:activity:a-task",
+      "Next": "Final"
+    },
+    "Final": {
+      "Type": "Fail"
+    }
+  }
+}


### PR DESCRIPTION
These two fields are listed as optional [in the documentation ](http://docs.aws.amazon.com/step-functions/latest/dg/awl-ref-states-fail.html) but required in the j2119 spec. Assuming the docs are correct, this PR reflects that in the spec and adds an rspec module for the general Linter class.

Happy to make any necessary fixes...I muddled through the Ruby as best I could 😄 

After writing the new test case, but before changing the j2119 file.
```
...........F

Failures:

  1) StateMachineLint should allow Fail states to omit optional Cause/Error fields
     Failure/Error: expect(problems.size).to eq(0)

       expected: 0
            got: 2

       (compared using ==)
     # ./spec/statelint_spec.rb:26:in `block (2 levels) in <top (required)>'

Finished in 0.0932 seconds (files took 0.11556 seconds to load)
12 examples, 1 failure

Failed examples:

rspec ./spec/statelint_spec.rb:21 # StateMachineLint should allow Fail states to omit optional Cause/Error fields
```

And post-change:
```
............

Finished in 0.05987 seconds (files took 0.11337 seconds to load)
12 examples, 0 failures
```