### PR TITLE
Return nonzero on error; fixes #3

### DIFF
--- a/bin/statelint
+++ b/bin/statelint
@@ -26,6 +26,8 @@ ARGV.each do |file|
     problems.each do |problem|
       puts " #{problem}"
     end
+
+  exit 1
   end
 end
 

--- a/statelint.gemspec
+++ b/statelint.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'statelint'
-  s.version     = '0.1.0'
+  s.version     = '0.1.1'
   s.date        = '2016-09-28'
   s.summary     = "State Machine JSON validator"
   s.description = "Validates a JSON object representing a State Machine"

--- a/test/test_retval.sh
+++ b/test/test_retval.sh
@@ -1,0 +1,17 @@
+# Should be run from the root of the repository
+
+ruby -I./lib bin/statelint test/has-dupes.json > /dev/null 2>&1
+
+if [ $? -eq 0 ]; then
+	echo "TEST FAILED: 0 returned for invalid JSON file"
+	exit 1
+fi
+
+ruby -I./lib bin/statelint test/minimal-fail-state.json > /dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+	echo "TEST FAILED: 0 not returned for valid JSON file"
+	exit 1
+fi
+
+echo "Return value test successful"


### PR DESCRIPTION
Issue #3 makes using statelint in any automated build system a pain - we use Makefiles quite extensively and it's highly non-intuitive for an application to fail and return 0.

This is a _very_ simple fix for the issue when running statelint as a command-line application.

(NB: I'm not a Ruby dev but I've tested this with the JSON files in the `test/` directory and got the expected output)