### PR TITLE
Fixes in .j2119 file for bugs #5 and #8, with unit tests

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -19,11 +19,10 @@ Each of a Succeed State and a Fail State is a "Terminal State".
 A State which is not a Terminal State or a Choice State MUST have a string field named "Next".
 A Terminal State MUST NOT have a field named "Next".
 A State MAY have a nullable-JSONPath field named "InputPath".
-A State MAY have a nullable-referencePath field named "ResultPath".
+Each of a Pass State, a Task State, a Wait State, and a Parallel State MAY have a nullable-referencePath field named "ResultPath".
 A State MAY have a nullable-JSONPath field named "OutputPath".
 A Pass State MAY have a field named "Result".
 A Fail State MUST NOT have a field named "InputPath".
-A Fail State MUST NOT have a field named "ResultPath".
 A Fail State MUST NOT have a field named "OutputPath".
 A Fail State MAY have a string field named "Cause".
 A Fail State MAY have a string field named "Error".
@@ -31,12 +30,12 @@ Each of a Task State and a Parallel State MAY have an object-array field named "
 A Task State MUST have a URI field named "Resource".
 A Task State MAY have a positive-integer field named "TimeoutSeconds" whose value MUST be less than 99999999.
 A Task State MAY have a positive-integer field named "HeartbeatSeconds" whose value MUST be less than 99999999.
-A Retrier MUST have a string-array field named "ErrorEquals".
+A Retrier MUST have a nonempty-string-array field named "ErrorEquals".
 A Retrier MAY have an positive-integer field named "IntervalSeconds".
 A Retrier MAY have a nonnegative-integer field named "MaxAttempts" whose value MUST be less than 99999999.
 A Retrier MAY have a float field named "BackoffRate" whose value MUST be greater than or equal to 1.0.
 Each of a Task State and a Parallel State MAY have an object-array field named "Catch"; each element is a "Catcher".
-A Catcher MUST have an string-array field named "ErrorEquals".
+A Catcher MUST have an nonempty-string-array field named "ErrorEquals".
 A Catcher MUST have a string field named "Next".
 A Catcher MAY have a nullable-referencePath field named "ResultPath".
 A Choice State MUST have a nonempty-object-array field named "Choices"; each element is a "Choice Rule".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -26,4 +26,64 @@ describe StateMachineLint do
     expect(problems.size).to eq(0)
   end
 
+  it 'should reject empty ErrorEquals clauses' do
+    j = File.read "test/empty-error-equals-on-catch.json"
+    linter = StateMachineLint::Linter.new
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    
+    j = File.read "test/empty-error-equals-on-retry.json"
+    linter = StateMachineLint::Linter.new
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+  end
+
+  it 'should reject ResultPath except in Pass, Task, and Parallel' do
+    j = File.read "test/pass-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    problems.each { |p| puts "P: #{p}" }
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/task-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    problems.each { |p| puts "P: #{p}" }
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/choice-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size > 0)
+
+    j = File.read "test/choice-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size > 0)
+
+    j = File.read "test/wait-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size > 0)
+
+    j = File.read "test/succeed-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size > 0)
+
+    j = File.read "test/fail-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size > 0)
+
+    j = File.read "test/parallel-with-resultpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    problems.each { |p| puts "P: #{p}" }
+    expect(problems.size).to eq(0)
+    
+  end
+
 end

--- a/test/choice-with-resultpath.json
+++ b/test/choice-with-resultpath.json
@@ -1,0 +1,19 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Choice",
+      "Choices": [
+	{
+	  "Variable": "$.foo",
+	  "StringEquals": "x",
+	  "Next": "x"
+	}
+      ],
+      "ResultPath": "$.foo"
+    },
+    "x": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/test/empty-error-equals-on-catch.json
+++ b/test/empty-error-equals-on-catch.json
@@ -1,0 +1,19 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "End": true,
+      "Catch": [
+	{
+	  "ErrorEquals": [],
+	  "Next": "x"
+	}
+      ]
+    },
+    "x": {
+      "Type": "Fail"
+    }
+  }
+}

--- a/test/empty-error-equals-on-retry.json
+++ b/test/empty-error-equals-on-retry.json
@@ -1,0 +1,15 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "End": true,
+      "Retry": [
+	{
+	  "ErrorEquals": []
+	}
+      ]
+    }
+  }
+}

--- a/test/fail-with-resultpath.json
+++ b/test/fail-with-resultpath.json
@@ -1,0 +1,9 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Fail",
+      "ResultPath": "$.foo"
+    }
+  }
+}

--- a/test/parallel-with-resultpath.json
+++ b/test/parallel-with-resultpath.json
@@ -1,0 +1,20 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Parallel",
+      "Branches": [
+	{
+	  "StartAt": "x",
+	  "States": {
+	    "x": {
+	      "Type": "Succeed"
+	    }
+	  }
+	}
+      ],
+      "ResultPath": "$.foo",
+      "End": true
+    }
+  }
+}

--- a/test/pass-with-resultpath.json
+++ b/test/pass-with-resultpath.json
@@ -1,0 +1,11 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Pass",
+      "Result": { "foo": 1 },
+      "ResultPath": "$.foo",
+      "End": true
+    }
+  }
+}

--- a/test/succeed-with-resultpath.json
+++ b/test/succeed-with-resultpath.json
@@ -1,0 +1,9 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Succeed",
+      "ResultPath": "$.foo"
+    }
+  }
+}

--- a/test/task-with-resultpath.json
+++ b/test/task-with-resultpath.json
@@ -1,0 +1,11 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "ResultPath": "$.foo",
+      "End": true
+    }
+  }
+}

--- a/test/wait-with-resultpath.json
+++ b/test/wait-with-resultpath.json
@@ -1,0 +1,11 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Wait",
+      "Seconds": 1,
+      "ResultPath": "$.foo",
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
Fix list of states ResultPath is allowed in.
Disallow empty ErroEquals lists.
Fixes bugs #8 and #5.