### PR TITLE
Fixed .j2119 and unit tests

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -13,13 +13,13 @@ A State whose "Type" field's value is "Choice" is a "Choice State".
 A State whose "Type" field's value is "Wait" is a "Wait State".
 A State whose "Type" field's value is "Parallel" is a "Parallel State".
 A State MAY have a string field named "Comment".
-Each of a Pass State, a Task State, and a Parallel State MAY have a boolean field named "End".
+Each of a Pass State, a Task State, a Wait State, and a Parallel State MAY have a boolean field named "End".
 A State whose "End" field's value is true is a "Terminal State".
 Each of a Succeed State and a Fail State is a "Terminal State".
 A State which is not a Terminal State or a Choice State MUST have a string field named "Next".
 A Terminal State MUST NOT have a field named "Next".
 A State MAY have a nullable-JSONPath field named "InputPath".
-Each of a Pass State, a Task State, a Wait State, and a Parallel State MAY have a nullable-referencePath field named "ResultPath".
+Each of a Pass State, a Task State, and a Parallel State MAY have a nullable-referencePath field named "ResultPath".
 A State MAY have a nullable-JSONPath field named "OutputPath".
 A Pass State MAY have a field named "Result".
 A Fail State MUST NOT have a field named "InputPath".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -32,12 +32,14 @@ describe StateMachineLint do
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(1)
+    expect (problems[0].include?('non-empty required'))
     
     j = File.read "test/empty-error-equals-on-retry.json"
     linter = StateMachineLint::Linter.new
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(1)
+    expect (problems[0].include?('non-empty required'))
   end
 
   it 'should reject ResultPath except in Pass, Task, and Parallel' do
@@ -56,27 +58,33 @@ describe StateMachineLint do
     j = File.read "test/choice-with-resultpath.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
-    expect(problems.size > 0)
+    expect(problems.size).to eq(1)
+    expect (problems[0].include?('"ResultPath"'))
 
     j = File.read "test/choice-with-resultpath.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
-    expect(problems.size > 0)
+    expect(problems.size).to eq(1)
+    expect (problems[0].include?('"ResultPath"'))
 
     j = File.read "test/wait-with-resultpath.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
-    expect(problems.size > 0)
+    expect(problems.size).to eq(1)
+    expect (problems[0].include?('"ResultPath"'))
+
 
     j = File.read "test/succeed-with-resultpath.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
-    expect(problems.size > 0)
+    expect(problems.size).to eq(1)
+    expect (problems[0].include?('"ResultPath"'))
 
     j = File.read "test/fail-with-resultpath.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
-    expect(problems.size > 0)
+    expect(problems.size).to eq(1)
+    expect (problems[0].include?('"ResultPath"'))
 
     j = File.read "test/parallel-with-resultpath.json"
     linter = StateMachineLint::Linter.new

--- a/statelint.gemspec
+++ b/statelint.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'statelint'
-  s.version     = '0.1.2'
+  s.version     = '0.1.4'
   s.date        = '2016-09-28'
   s.summary     = "State Machine JSON validator"
   s.description = "Validates a JSON object representing a State Machine"


### PR DESCRIPTION
Fat-fingering the .j2119 file revealed that unit tests didn't catch obvious errors. Fixed.