### PR TITLE
Remove unnecessary JSON conversion

### DIFF
--- a/spec/state_node_spec.rb
+++ b/spec/state_node_spec.rb
@@ -13,51 +13,53 @@
 #!/usr/bin/env ruby
 
 $:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
-require 'json'
 require 'statelint/state_node'
+require 'json'
 
 describe StateMachineLint::StateNode do
 
   it 'should find missing StartAt targets' do
-    json = '{ "StartAt": "x", ' +
-           '  "States": {' +
-           '    "y": {"Type":"Succeed"} ' +
-           '  }'  +
-           '}'
+    json = {
+      "StartAt" => "x",
+      "States" => {
+        "y" => {
+          "Type" => "Succeed"
+        }
+      }
+    }
 
-    json = JSON.parse json
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
-    # problems.each {|p| puts "P #{p}"}
     expect(problems.size).to eq(2)
   end
 
   it 'should catch nested problems' do
-    json = '{ "StartAt": "x", ' +
-           ' "States": { ' +
-           '  "x": {' +
-           '   "StartAt": "z",' +
-           '   "States": { ' +
-           '    "w": 1' +
-           '   }' +
-           '  }' +
-           ' }' +
-           '}'
-    json = JSON.parse json
+    json = {
+      "StartAt" => "x",
+      "States" => {
+        "x" => {
+          "StartAt" => "z",
+          "States" => {
+            "w" => 1
+          }
+        }
+      }
+    }
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
     expect(problems.size).to eq(4)
   end
-  
+
   it 'should find States.ALL not in end position' do
-    json = '{ "Retry": [' +
-           '  { "ErrorEquals": [ "States.ALL", "other" ] },'  +
-           '  { "ErrorEquals": [ "YET ANOTHER" ] } ' +
-           ' ] ' +
-           '}'
-    json = JSON.parse json
+    json = {
+      "Retry" => [
+        { "ErrorEquals" => ["States.ALL", "other"] },
+        { "ErrorEquals" => ["YET ANOTHER"] },
+      ]
+    }
+
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
@@ -65,12 +67,12 @@ describe StateMachineLint::StateNode do
   end
 
   it 'should find States.ALL not by itself' do
-    json = '{ "Retry": [' +
-           '  { "ErrorEquals": [ "YET ANOTHER" ] }, ' +
-           '  { "ErrorEquals": [ "States.ALL", "other" ] }'  +
-           ' ] ' +
-           '}'
-    json = JSON.parse json
+    json = {
+      "Retry" => [
+        { "ErrorEquals" => ["YET ANOTHER"] },
+        { "ErrorEquals" => ["States.ALL", "other"] },
+      ]
+    }
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
@@ -78,9 +80,9 @@ describe StateMachineLint::StateNode do
   end
 
   it 'should use Default field correctly' do
-    text = {
-      "StartAt"=> "A",
-      "States"=> {
+    json = {
+      "StartAt" => "A",
+      "States" => {
         "A" => {
           "Type" => "Choice",
           "Choices" => [
@@ -99,7 +101,6 @@ describe StateMachineLint::StateNode do
         }
       }
     }
-    json = JSON.parse(JSON.pretty_generate(text))
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
@@ -107,16 +108,15 @@ describe StateMachineLint::StateNode do
   end
 
   it "should find Next fields with targets that don't match state names" do
-    text = {
-      "StartAt"=> "A",
-      "States"=> {
+    json = {
+      "StartAt" => "A",
+      "States" => {
         "A" => {
           "Type" => "Pass",
           "Next" => "B"
         }
       }
     }
-    json = JSON.parse(JSON.pretty_generate(text))
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
@@ -124,9 +124,9 @@ describe StateMachineLint::StateNode do
   end
 
   it "should find un-pointed-to states" do
-    text = {
-      "StartAt"=> "A",
-      "States"=> {
+    json = {
+      "StartAt" => "A",
+      "States" => {
         "A" => {
           "Type" => "Succeed"
         },
@@ -135,7 +135,6 @@ describe StateMachineLint::StateNode do
         }
       }
     }
-    json = JSON.parse(JSON.pretty_generate(text))
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
@@ -143,9 +142,9 @@ describe StateMachineLint::StateNode do
   end
 
   it "should find missing terminal state" do
-    text = {
-      "StartAt"=> "A",
-      "States"=> {
+    json = {
+      "StartAt" => "A",
+      "States" => {
         "A" => {
           "Type" => "Pass",
           "Next" => "B",
@@ -156,7 +155,6 @@ describe StateMachineLint::StateNode do
         }
       }
     }
-    json = JSON.parse(JSON.pretty_generate(text))
     problems = []
     checker = StateMachineLint::StateNode.new
     checker.check(json, 'a.b', problems)
@@ -188,7 +186,6 @@ describe StateMachineLint::StateNode do
     checker = StateMachineLint::StateNode.new
     checker.check(j, 'a.b', problems)
     expect(problems.size).to eq(1)
-    # problems.each {|p| puts "P #{p}"}
   end
 
 end


### PR DESCRIPTION
In `state_node_spec.rb`, your tests are a little hard to read. 

You're building JSON using, then parsing it with the `json` gem, but then your `check` method takes a Hash. I think building a `Hash` is a cleaner approach as it makes your tests easier to read.

If you really, really want strings, may I suggest using heredocs?

```ruby
json = <<~JSON
{ "StartAt" ...
JSON
```