### PR TITLE
Bump gem version to 0.3.0.

### DIFF
--- a/statelint.gemspec
+++ b/statelint.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'statelint'
-  s.version     = '0.2.0'
-  s.date        = '2016-09-28'
+  s.version     = '0.3.0'
   s.summary     = "State Machine JSON validator"
   s.description = "Validates a JSON object representing a State Machine"
   s.authors     = ["Tim Bray"]
@@ -11,7 +10,15 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|test)/})
   end
 
-  s.homepage    = 'http://rubygems.org/gems/statelint'
-  s.license     = 'Apache 2.0'
-  s.add_runtime_dependency "j2119"
+  s.homepage    = 'https://github.com/awslabs/statelint'
+  s.license     = 'Apache-2.0'
+
+  s.required_ruby_version = '>= 1.9.2'
+
+  s.add_runtime_dependency 'j2119', '>= 0.3.0'
+
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/awslabs/statelint',
+    "bug_tracker_uri"   => 'https://github.com/awslabs/statelint/issues'
+  }
 end


### PR DESCRIPTION
*Description of changes:* This bumps the Gem version to 0.3.0, enabling updating the gem in [Rubygems](https://rubygems.org/gems/statelint/). This also updates the gemspec to point at the Github repository for source code and for issues, and states that Ruby 1.9.2 or above is required. Ruby 1.9 has been standard in the community for nearly a decade, so this shouldn't be a burdensome requirement. It's also required transitively through the JSON dependency that we pull in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
