### PR TITLE
Allow multiple files to be linted on cli

### DIFF
--- a/bin/statelint
+++ b/bin/statelint
@@ -17,17 +17,22 @@ require 'statelint'
 linter = StateMachineLint::Linter.new
 
 # arguments are JSON filenames
-ARGV.each do |file|
-  problems = linter.validate(ARGV[0])
+linted_files = ARGV.map { |file|
+  [file, linter.validate(file)]
+}.to_h
 
-  if !problems.empty?
-    header = (problems.size == 1) ? 'One error:' : "#{problems.size} errors:"
-    puts header
-    problems.each do |problem|
-      puts " #{problem}"
-    end
+problem_count = linted_files.values.flatten.compact.count
 
-  exit 1
-  end
-end
+exit if problem_count <= 0
 
+linted_files.each { |file, problems|
+  problem_size = problems.size
+  
+  next if problem_size <= 0
+
+  header = problem_size == 1 ? 'One error' : "#{problem_size} errors"
+  puts header + ": for #{file}"
+  puts " #{problems.join("\n ")}"
+}
+
+exit 1


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
At the moment, the `statelint` command only lints the first file passed as an argument. For example, the following will only lint `snapshot.json`:

```shell
statelint snapshot.json processing.json
# 2 errors:
# State Machine.States.create_partition.Resource is "${partition_lambda}" but should be A URI
# State Machine.States.import.Resource is "${import_lambda}" but should be A URI
```

This update will lint all files passed to the command and output the results, or exit if there are no issues found:

```shell
statelint snapshot.json processing.json
# 2 errors: for snapshot.json
#  State Machine.States.create_partition.Resource is "${partition_lambda}" but should be A URI
#  State Machine.States.import.Resource is "${import_lambda}" but should be A URI
# 9 errors: for processing.json
#  State Machine.States.header_create.Resource is "${header_create_lambda}" but should be A URI
#  State Machine.States.validation_status.Resource is "${validation_status_lambda}" but should be A URI
#  State Machine.States.invalid_wrap_up.Branches[0].States.start_crawler_failure.Resource is "${crawler_start_lambda}" but should be A URI
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
