### PR TITLE
Adding validation support for ASL enhancements

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -20,9 +20,10 @@ A State whose "End" field's value is true is a "Terminal State".
 Each of a Succeed State and a Fail State is a "Terminal State".
 A State which is not a Terminal State or a Choice State MUST have a string field named "Next".
 A Terminal State MUST NOT have a field named "Next".
-A State MAY have a nullable-JSONPath field named "InputPath".
+A State MAY have a field named "InputPath".
 Each of a Pass State, a Task State, a Parallel State, and a Map State MAY have a nullable-referencePath field named "ResultPath".
-A State MAY have a nullable-JSONPath field named "OutputPath".
+Each of a Task State, a Parallel State, and a Map State MAY have a field named "ResultSelector".
+A State MAY have a field named "OutputPath".
 A Pass State MAY have a field named "Result".
 A Fail State MUST NOT have a field named "InputPath".
 A Fail State MUST NOT have a field named "OutputPath".
@@ -32,6 +33,10 @@ Each of a Task State, a Parallel State, and a Map State MAY have an object-array
 A Task State MUST have a URI field named "Resource".
 A Task State MAY have a positive-integer field named "TimeoutSeconds" whose value MUST be less than 99999999.
 A Task State MAY have a positive-integer field named "HeartbeatSeconds" whose value MUST be less than 99999999.
+A Task State MAY have a referencePath field named "TimeoutSecondsPath".
+A Task State MAY have a referencePath field named "HeartbeatSecondsPath".
+A Task State MAY have only one of "TimeoutSeconds" and "TimeoutSecondsPath".
+A Task State MAY have only one of "HeartbeatSeconds" and "HeartbeatSecondsPath".
 A Retrier MUST have a nonempty-string-array field named "ErrorEquals".
 A Retrier MAY have an positive-integer field named "IntervalSeconds".
 A Retrier MAY have a nonnegative-integer field named "MaxAttempts" whose value MUST be less than 99999999.
@@ -51,9 +56,9 @@ A Choice Rule MUST have a string field named "Next".
 A Choice Rule with an "And" field is a "Boolean".
 A Choice Rule with an "Or" field is a "Boolean".
 A Choice Rule with a "Not" field is a "Boolean".
-A Choice Rule MAY have a referencePath field named "Variable".
+A Choice Rule MAY have a field named "Variable".
 A Choice Rule with a "Variable" field is a "Comparison".
-A Comparison MUST have a field named one of "StringEquals", "StringLessThan", "StringGreaterThan", "StringLessThanEquals", "StringGreaterThanEquals", "NumericEquals", "NumericLessThan", "NumericGreaterThan", "NumericLessThanEquals", "NumericGreaterThanEquals", "BooleanEquals", "TimestampEquals", "TimestampLessThan", "TimestampGreaterThan", "TimestampLessThanEquals", or "TimestampGreaterThanEquals".
+A Comparison MUST have a field named one of "StringEquals", "StringLessThan", "StringGreaterThan", "StringLessThanEquals", "StringGreaterThanEquals", "NumericEquals", "NumericLessThan", "NumericGreaterThan", "NumericLessThanEquals", "NumericGreaterThanEquals", "BooleanEquals", "TimestampEquals", "TimestampLessThan", "TimestampGreaterThan", "TimestampLessThanEquals", "TimestampGreaterThanEquals", "StringEqualsPath", "StringLessThanPath", "StringGreaterThanPath", "StringLessThanEqualsPath", "StringGreaterThanEqualsPath", "NumericEqualsPath", "NumericLessThanPath", "NumericGreaterThanPath", "NumericLessThanEqualsPath", "NumericGreaterThanEqualsPath", "BooleanEqualsPath", "TimestampEqualsPath", "TimestampLessThanPath", "TimestampGreaterThanPath", "TimestampLessThanEqualsPath", "TimestampGreaterThanEqualsPath", "IsNull", "IsPresent", "IsNumeric", "IsString", "IsBoolean", "IsTimestamp", or "StringMatches".
 A Comparison MAY have a string field named "StringEquals".
 A Comparison MAY have a string field named "StringLessThan".
 A Comparison MAY have a string field named "StringGreaterThan".
@@ -70,6 +75,29 @@ A Comparison MAY have a timestamp field named "TimestampLessThan".
 A Comparison MAY have a timestamp field named "TimestampGreaterThan".
 A Comparison MAY have a timestamp field named "TimestampLessThanEquals".
 A Comparison MAY have a timestamp field named "TimestampGreaterThanEquals".
+A Comparison MAY have a boolean field named "IsNull".
+A Comparison MAY have a boolean field named "IsPresent".
+A Comparison MAY have a boolean field named "IsNumeric".
+A Comparison MAY have a boolean field named "IsString".
+A Comparison MAY have a boolean field named "IsBoolean".
+A Comparison MAY have a boolean field named "IsTimestamp".
+A Comparison MAY have a string field named "StringMatches".
+A Comparison MAY have a referencePath field named "StringEqualsPath".
+A Comparison MAY have a referencePath field named "StringLessThanPath".
+A Comparison MAY have a referencePath field named "StringGreaterThanPath".
+A Comparison MAY have a referencePath field named "StringLessThanEqualsPath".
+A Comparison MAY have a referencePath field named "StringGreaterThanEqualsPath".
+A Comparison MAY have a referencePath field named "NumericEqualsPath".
+A Comparison MAY have a referencePath field named "NumericLessThanPath".
+A Comparison MAY have a referencePath field named "NumericGreaterThanPath".
+A Comparison MAY have a referencePath field named "NumericLessThanEqualsPath".
+A Comparison MAY have a referencePath field named "NumericGreaterThanEqualsPath".
+A Comparison MAY have a referencePath field named "BooleanEqualsPath".
+A Comparison MAY have a referencePath field named "TimestampEqualsPath".
+A Comparison MAY have a referencePath field named "TimestampLessThanPath".
+A Comparison MAY have a referencePath field named "TimestampGreaterThanPath".
+A Comparison MAY have a referencePath field named "TimestampLessThanEqualsPath".
+A Comparison MAY have a referencePath field named "TimestampGreaterThanEqualsPath".
 A Comparison MUST NOT have a field named "And".
 A Comparison MUST NOT have a field named "Or".
 A Comparison MUST NOT have a field named "Not".
@@ -80,7 +108,7 @@ A Nested Rule with an "And" field is a "Nested Boolean".
 A Nested Rule with an "Or" field is a "Nested Boolean".
 A Nested Rule with a "Not" field is a "Nested Boolean".
 A Nested Rule MUST NOT have a field named "Next".
-A Nested Rule MAY have a referencePath field named "Variable".
+A Nested Rule MAY have a field named "Variable".
 A Nested Rule with a "Variable" field is a "Nested Comparison".
 A Nested Comparison MAY have a string field named "StringEquals".
 A Nested Comparison MAY have a string field named "StringLessThan".
@@ -98,6 +126,29 @@ A Nested Comparison MAY have a timestamp field named "TimestampLessThan".
 A Nested Comparison MAY have a timestamp field named "TimestampGreaterThan".
 A Nested Comparison MAY have a timestamp field named "TimestampLessThanEquals".
 A Nested Comparison MAY have a timestamp field named "TimestampGreaterThanEquals".
+A Nested Comparison MAY have a boolean field named "IsNull".
+A Nested Comparison MAY have a boolean field named "IsPresent".
+A Nested Comparison MAY have a boolean field named "IsNumeric".
+A Nested Comparison MAY have a boolean field named "IsString".
+A Nested Comparison MAY have a boolean field named "IsBoolean".
+A Nested Comparison MAY have a boolean field named "IsTimestamp".
+A Nested Comparison MAY have a string field named "StringMatches".
+A Nested Comparison MAY have a referencePath field named "StringEqualsPath".
+A Nested Comparison MAY have a referencePath field named "StringLessThanPath".
+A Nested Comparison MAY have a referencePath field named "StringGreaterThanPath".
+A Nested Comparison MAY have a referencePath field named "StringLessThanEqualsPath".
+A Nested Comparison MAY have a referencePath field named "StringGreaterThanEqualsPath".
+A Nested Comparison MAY have a referencePath field named "NumericEqualsPath".
+A Nested Comparison MAY have a referencePath field named "NumericLessThanPath".
+A Nested Comparison MAY have a referencePath field named "NumericGreaterThanPath".
+A Nested Comparison MAY have a referencePath field named "NumericLessThanEqualsPath".
+A Nested Comparison MAY have a referencePath field named "NumericGreaterThanEqualsPath".
+A Nested Comparison MAY have a referencePath field named "BooleanEqualsPath".
+A Nested Comparison MAY have a referencePath field named "TimestampEqualsPath".
+A Nested Comparison MAY have a referencePath field named "TimestampLessThanPath".
+A Nested Comparison MAY have a referencePath field named "TimestampGreaterThanPath".
+A Nested Comparison MAY have a referencePath field named "TimestampLessThanEqualsPath".
+A Nested Comparison MAY have a referencePath field named "TimestampGreaterThanEqualsPath".
 A Nested Comparison MUST NOT have a field named "And".
 A Nested Comparison MUST NOT have a field named "Or".
 A Nested Comparison MUST NOT have a field named "Not".
@@ -109,7 +160,7 @@ A Wait State MUST have only one of "Seconds", "SecondsPath", "Timestamp", and "T
 A Wait State MUST have a field named one of "Seconds", "SecondsPath", "Timestamp", or "TimestampPath".
 A Parallel State MUST have an object-array field named "Branches"; each element is a "Branch".
 A Map State MUST have an object field named "Iterator"; its value is a "Branch".
-A Map State MAY have a referencePath field named "ItemsPath".
+A Map State MAY have a field named "ItemsPath".
 A Map State MAY have a numeric field named "MaxConcurrency".
 A Branch MUST have an object field named "States"; each field is a "State".
 A Branch MUST have a string field named "StartAt".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -143,7 +143,154 @@ describe StateMachineLint do
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
-
   end
 
+  it 'should allow context object access in InputPath and OutputPath' do
+    j = File.read "test/pass-with-io-path-context-object.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should allow context object access in Choice state Variable' do
+    j = File.read "test/choice-with-context-object.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end 
+
+  it 'should allow context object access in Map state ItemsPath' do
+    j = File.read "test/map-with-itemspath-context-object.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+    
+  it 'should allow dynamic timeout fields in Task state' do
+    j = File.read "test/task-with-dynamic-timeouts.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should allow null values in InputPath and OutputPath' do
+    j = File.read "test/pass-with-null-inputpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/pass-with-null-outputpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should not allow null value in Map state ItemsPath' do
+    j = File.read "test/map-with-null-itemspath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('"ItemsPath"')
+  end
+
+  it 'should reject ResultSelector except in Task, Parallel, and Map states' do
+    j = File.read "test/task-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/parallel-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/map-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/pass-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('"ResultSelector"')
+
+    j = File.read "test/wait-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('"ResultSelector"')
+
+    j = File.read "test/fail-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('"ResultSelector"')
+
+    j = File.read "test/succeed-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('"ResultSelector"')
+
+    j = File.read "test/choice-with-resultselector.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('"ResultSelector"')
+  end
+
+  it 'should allow only valid intrinsic function invocations in payload builder fields' do
+    j = File.read "test/states-array-invocation.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/states-format-invocation.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/states-stringtojson-invocation.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/states-jsontostring-invocation.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+
+    j = File.read "test/states-array-invocation-leftpad.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('not a JSONPath or intrinsic function expression')
+
+    j = File.read "test/invalid-function-invocation.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('not a JSONPath or intrinsic function expression')
+
+    j = File.read "test/pass-with-intrinsic-function-inputpath.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('"InputPath"')
+  end
+
+  it 'should reject Task state with both static and dynamic timeouts' do
+    j = File.read "test/task-with-static-and-dynamic-timeout.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('may have only one of ["TimeoutSeconds", "TimeoutSecondsPath"]')
+
+    j = File.read "test/task-with-static-and-dynamic-heartbeat.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('may have only one of ["HeartbeatSeconds", "HeartbeatSecondsPath"]')
+  end
 end

--- a/statelint.gemspec
+++ b/statelint.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'statelint'
-  s.version     = '0.4.1'
+  s.version     = '0.5.0'
   s.summary     = "State Machine JSON validator"
   s.description = "Validates a JSON object representing a State Machine"
   s.authors     = ["Tim Bray"]

--- a/test/choice-with-context-object.json
+++ b/test/choice-with-context-object.json
@@ -1,0 +1,22 @@
+{
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$$.value",
+                    "IsNull": false,
+                    "Next": "SucceedState"
+                }
+            ],
+            "Default": "FailState"
+        },
+        "SucceedState": {
+            "Type": "Succeed"
+        },
+        "FailState": {
+            "Type": "Fail"
+        }
+    }
+}

--- a/test/choice-with-resultselector.json
+++ b/test/choice-with-resultselector.json
@@ -1,0 +1,23 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Choice",
+      "Choices": [
+	{
+	  "Variable": "$.foo",
+	  "StringEquals": "x",
+	  "Next": "x"
+	}
+      ],
+      "ResultSelector": {
+        "a": "x",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      }
+    },
+    "x": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/test/fail-with-resultselector.json
+++ b/test/fail-with-resultselector.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Fail",
+      "ResultSelector": {
+        "a": "x",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      }
+    }
+  }
+}

--- a/test/invalid-function-invocation.json
+++ b/test/invalid-function-invocation.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "ResultSelector": {
+          "abc.$": "States.Xyz($.result)"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/map-with-itemspath-context-object.json
+++ b/test/map-with-itemspath-context-object.json
@@ -1,0 +1,21 @@
+{
+    "StartAt": "m",
+    "States": {
+      "m": {
+        "Type": "Map",
+        "ItemsPath": "$$.mapItems",
+        "Iterator":	{
+          "StartAt": "x",
+          "States": {
+            "x": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        },
+        "Parameters": "$.foo",
+        "End": true
+      }
+    }
+  }
+  

--- a/test/map-with-null-itemspath.json
+++ b/test/map-with-null-itemspath.json
@@ -1,0 +1,20 @@
+{
+  "StartAt": "m",
+  "States": {
+    "m": {
+      "Type": "Map",
+      "ItemsPath": null,
+      "Iterator":	{
+        "StartAt": "x",
+        "States": {
+          "x": {
+            "Type": "Pass",
+            "End": true
+          }
+        }
+      },
+      "Parameters": "$.foo",
+      "End": true
+    }
+  }
+}

--- a/test/map-with-resultselector.json
+++ b/test/map-with-resultselector.json
@@ -1,0 +1,24 @@
+{
+  "StartAt": "m",
+  "States": {
+    "m": {
+      "Type": "Map",
+      "Iterator":	{
+        "StartAt": "x",
+        "States": {
+          "x": {
+            "Type": "Pass",
+            "End": true
+          }
+        }
+      },
+      "Parameters": "$.foo",
+      "ResultSelector": {
+        "a": "x",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/parallel-with-resultselector.json
+++ b/test/parallel-with-resultselector.json
@@ -1,0 +1,25 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Parallel",
+      "Branches": [
+	{
+	  "StartAt": "x",
+	  "States": {
+	    "x": {
+	      "Type": "Succeed"
+	    }
+	  }
+	}
+      ],
+      "Parameters": "$.foo",
+      "ResultSelector": {
+        "a": "x",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/pass-with-intrinsic-function-inputpath.json
+++ b/test/pass-with-intrinsic-function-inputpath.json
@@ -1,0 +1,12 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Pass",
+        "Result": { "foo": 1 , "bar": 2},
+        "InputPath": "States.Format('{} xyz {}', 1, 'def')",
+        "End": true
+      }
+    }
+  }
+  

--- a/test/pass-with-io-path-context-object.json
+++ b/test/pass-with-io-path-context-object.json
@@ -1,0 +1,13 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Pass",
+        "Result": { "foo": 1 , "bar": 2},
+        "InputPath": "$$.path.inputToProcess",
+        "OutputPath": "$$.outputToPass", 
+        "End": true
+      }
+    }
+  }
+  

--- a/test/pass-with-null-inputpath.json
+++ b/test/pass-with-null-inputpath.json
@@ -1,0 +1,12 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Pass",
+        "Result": { "foo": 1 , "bar": 2},
+        "InputPath": null,
+        "End": true
+      }
+    }
+  }
+  

--- a/test/pass-with-null-outputpath.json
+++ b/test/pass-with-null-outputpath.json
@@ -1,0 +1,12 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Pass",
+        "Result": { "foo": 1 , "bar": 2},
+        "OutputPath": null, 
+        "End": true
+      }
+    }
+  }
+  

--- a/test/pass-with-resultselector.json
+++ b/test/pass-with-resultselector.json
@@ -1,0 +1,15 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Pass",
+      "Result": { "foo": 1 },
+      "ResultSelector": {
+        "a": "$.foo",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/states-array-invocation-leftpad.json
+++ b/test/states-array-invocation-leftpad.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "ResultSelector": {
+          "abc.$": " States.Array('Foo', $.xyz, 'Bar', 2.3)"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/states-array-invocation.json
+++ b/test/states-array-invocation.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "ResultSelector": {
+          "abc.$": "States.Array('Foo', $.xyz, 'Bar', 2.3)"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/states-format-invocation.json
+++ b/test/states-format-invocation.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "Parameters": {
+          "abc.$": "States.Format('{} xyz {}', 1, 'def')"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/states-jsontostring-invocation.json
+++ b/test/states-jsontostring-invocation.json
@@ -1,0 +1,14 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Task",
+        "Resource": "foo:bar",
+        "Parameters": {
+            "abc.$": "States.JsonToString($.xyz)"
+        },
+        "End": true
+      }
+    }
+  }
+  

--- a/test/states-stringtojson-invocation.json
+++ b/test/states-stringtojson-invocation.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "ResultSelector": {
+          "abc.$": "States.StringToJson($.result)"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/succeed-with-resultselector.json
+++ b/test/succeed-with-resultselector.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Succeed",
+      "ResultSelector": {
+        "a": "x",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      }
+    }
+  }
+}

--- a/test/task-with-dynamic-timeouts.json
+++ b/test/task-with-dynamic-timeouts.json
@@ -1,0 +1,13 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Task",
+        "Resource": "foo:bar",
+        "TimeoutSecondsPath": "$.x",
+        "HeartbeatSecondsPath": "$.y",
+        "End": true
+      }
+    }
+  }
+  

--- a/test/task-with-resultselector.json
+++ b/test/task-with-resultselector.json
@@ -1,0 +1,15 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "ResultSelector": {
+        "a": "x",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/task-with-static-and-dynamic-heartbeat.json
+++ b/test/task-with-static-and-dynamic-heartbeat.json
@@ -1,0 +1,13 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Task",
+        "Resource": "foo:bar",
+        "HeartbeatSeconds": 30,
+        "HeartbeatSecondsPath": "$.abc",
+        "End": true
+      }
+    }
+  }
+  

--- a/test/task-with-static-and-dynamic-timeout.json
+++ b/test/task-with-static-and-dynamic-timeout.json
@@ -1,0 +1,13 @@
+{
+    "StartAt": "p",
+    "States": {
+      "p": {
+        "Type": "Task",
+        "Resource": "foo:bar",
+        "TimeoutSeconds": 30,
+        "TimeoutSecondsPath": "$.abc",
+        "End": true
+      }
+    }
+  }
+  

--- a/test/wait-with-resultselector.json
+++ b/test/wait-with-resultselector.json
@@ -1,0 +1,15 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Wait",
+      "Seconds": 1,
+      "ResultSelector": {
+        "a": "x",
+        "b.$": "$.y",
+        "c.$": "$$.z"
+      },
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the new ASL enhancements, adding support for:

1. Context object access in `InputPath`, `OutputPath`, `ItemsPath`. `InputPath` and `OutputPath` fields can be null.
2. Dynamic timeout fields in Task state: `TimeoutSecondsPath`, `HeartbeatSecondsPath` which accept reference paths.
3. Support for new Choice state operators.
4. `Variable` field in Choice states can access context object.
5.  Support for new `ResultSelector` field in Task, Map and Parallel states which is similar to `Parameters`.
6.  Support for intrinsic function invocations in payload builder fields. Based on discussion from ASL team stakeholders, we will only validate with a regex that will check that the string starts with `States.ValidFunctionName(…)` and has opening and closing parentheses.

Test run:

```
╰─ rake                                                                                                                                                                           ─╯
/Users/surivaib/.rbenv/versions/2.5.8/bin/ruby -I/Users/surivaib/.rbenv/versions/2.5.8/lib/ruby/gems/2.5.0/gems/rspec-support-3.9.3/lib:/Users/surivaib/.rbenv/versions/2.5.8/lib/ruby/gems/2.5.0/gems/rspec-core-3.9.2/lib /Users/surivaib/.rbenv/versions/2.5.8/lib/ruby/gems/2.5.0/gems/rspec-core-3.9.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.........................

Finished in 2.38 seconds (files took 0.22359 seconds to load)
25 examples, 0 failures
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
