### PR TITLE
Read JSON definition from file or STDIN

### DIFF
--- a/bin/statelint
+++ b/bin/statelint
@@ -16,18 +16,16 @@ require 'statelint'
 
 linter = StateMachineLint::Linter.new
 
-# arguments are JSON filenames
-ARGV.each do |file|
-  problems = linter.validate(ARGV[0])
+# arguments are JSON filenames or STDIN
+problems = linter.validate(ARGF.file)
 
-  if !problems.empty?
-    header = (problems.size == 1) ? 'One error:' : "#{problems.size} errors:"
-    puts header
-    problems.each do |problem|
-      puts " #{problem}"
-    end
-
-  exit 1
+if !problems.empty?
+  header = (problems.size == 1) ? 'One error:' : "#{problems.size} errors:"
+  puts header
+  problems.each do |problem|
+    puts " #{problem}"
   end
+
+exit 1
 end
 


### PR DESCRIPTION
Title says it all.  
Tested on 2.6.3p62 and 1.9.3p551 in Docker since I couldn't get 1.9.2p0 to build on my Mac using rbenv

*Description of changes:*
  - Uses ARGF.file to deal returning an IO or File class to pass to the validator
  - Removed a useless loop
This was thrown together with 0 prior ruby experience and about 10 minutes of skimming the ruby docs, so apologies ahead of time if I'm breaking any conventions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
