### PR TITLE
Allow comment field in catcher

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -45,6 +45,7 @@ Each of a Task State, a Parallel State, and a Map State MAY have an object-array
 A Catcher MUST have an nonempty-string-array field named "ErrorEquals".
 A Catcher MUST have a string field named "Next".
 A Catcher MAY have a nullable-referencePath field named "ResultPath".
+A Catcher MAY have a string field named "Comment".
 A Choice State MUST have a nonempty-object-array field named "Choices"; each element is a "Choice Rule".
 A Choice State MUST NOT have a field named "Next".
 A Choice State MUST NOT have a field named "End".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -213,7 +213,7 @@ describe StateMachineLint do
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
-  end 
+  end
 
   it 'should allow context object access in Map state ItemsPath' do
     j = File.read "test/map-with-itemspath-context-object.json"
@@ -221,7 +221,7 @@ describe StateMachineLint do
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
   end
-    
+
   it 'should allow dynamic timeout fields in Task state' do
     j = File.read "test/task-with-dynamic-timeouts.json"
     linter = StateMachineLint::Linter.new
@@ -390,6 +390,13 @@ describe StateMachineLint do
   it 'should allow Choice Rule to use Comment' do
     j = File.read "test/choice-rule-with-comment.json"
     j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should allow a Comment field in Catcher' do
+    j = File.read "test/succeed-with-comment-in-catcher.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(0)

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -157,7 +157,7 @@ describe StateMachineLint do
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
-  end 
+  end
 
   it 'should allow context object access in Map state ItemsPath' do
     j = File.read "test/map-with-itemspath-context-object.json"
@@ -165,7 +165,7 @@ describe StateMachineLint do
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
   end
-    
+
   it 'should allow dynamic timeout fields in Task state' do
     j = File.read "test/task-with-dynamic-timeouts.json"
     linter = StateMachineLint::Linter.new
@@ -292,5 +292,12 @@ describe StateMachineLint do
     problems = linter.validate(j)
     expect(problems.size).to eq(1)
     expect(problems[0]).to include('may have only one of ["HeartbeatSeconds", "HeartbeatSecondsPath"]')
+  end
+
+  it 'should allow a Comment field in Catcher' do
+    j = File.read "test/succeed-with-comment-in-catcher.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
   end
 end

--- a/test/succeed-with-comment-in-catcher.json
+++ b/test/succeed-with-comment-in-catcher.json
@@ -1,0 +1,23 @@
+{
+  "Comment": "test",
+  "StartAt": "foo",
+  "States": {
+    "foo": {
+      "Type":"Task",
+      "Resource":"arn:aws:states:::lambda:invoke",
+      "Next": "end",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "foo",
+          "Next": "end"
+        }
+      ]
+    },
+    "end": {
+      "Type": "Fail"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allows `Comment` field in `Catch` statements.

![image](https://user-images.githubusercontent.com/25471619/172453280-09f7c26f-b5da-4a09-8241-4ac3128efc3f.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
