### PR TITLE
Allow comment field in choice rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 *.gem
+.bundle
+vendor

--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -64,6 +64,7 @@ A Choice Rule with an "Or" field is a "Boolean".
 A Choice Rule with a "Not" field is a "Boolean".
 A Choice Rule MAY have a field named "Variable".
 A Choice Rule with a "Variable" field is a "Comparison".
+A Choice Rule MAY have a string field named "Comment".
 A Comparison MUST have a field named one of "StringEquals", "StringLessThan", "StringGreaterThan", "StringLessThanEquals", "StringGreaterThanEquals", "NumericEquals", "NumericLessThan", "NumericGreaterThan", "NumericLessThanEquals", "NumericGreaterThanEquals", "BooleanEquals", "TimestampEquals", "TimestampLessThan", "TimestampGreaterThan", "TimestampLessThanEquals", "TimestampGreaterThanEquals", "StringEqualsPath", "StringLessThanPath", "StringGreaterThanPath", "StringLessThanEqualsPath", "StringGreaterThanEqualsPath", "NumericEqualsPath", "NumericLessThanPath", "NumericGreaterThanPath", "NumericLessThanEqualsPath", "NumericGreaterThanEqualsPath", "BooleanEqualsPath", "TimestampEqualsPath", "TimestampLessThanPath", "TimestampGreaterThanPath", "TimestampLessThanEqualsPath", "TimestampGreaterThanEqualsPath", "IsNull", "IsPresent", "IsNumeric", "IsString", "IsBoolean", "IsTimestamp", or "StringMatches".
 A Comparison MAY have a string field named "StringEquals".
 A Comparison MAY have a string field named "StringLessThan".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -386,4 +386,12 @@ describe StateMachineLint do
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
   end
+
+  it 'should allow Choice Rule to use Comment' do
+    j = File.read "test/choice-rule-with-comment.json"
+    j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
 end

--- a/test/choice-rule-with-comment.json
+++ b/test/choice-rule-with-comment.json
@@ -1,0 +1,19 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.foo",
+          "StringEquals": "x",
+          "Next": "x",
+          "Comment": "foo"
+        }
+      ]
+    },
+    "x": {
+      "Type": "Succeed"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allows `Comment` field in `Choice Rule`. These appear as labels on branches in the state diagram.

![Screenshot 2023-12-05 at 7 43 51 AM](https://github.com/awslabs/statelint/assets/5218201/ffac30c3-175f-45d1-afcb-1dffa859e060)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
