### PR TITLE
allow comment in catcher

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -172,3 +172,4 @@ A Map State MAY have a numeric field named "MaxConcurrency".
 A Branch MUST have an object field named "States"; each field is a "State".
 A Branch MUST have a string field named "StartAt".
 A Branch MAY have a string field named "Comment".
+A Catcher MAY have a string field named "Comment".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -213,7 +213,7 @@ describe StateMachineLint do
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
-  end 
+  end
 
   it 'should allow context object access in Map state ItemsPath' do
     j = File.read "test/map-with-itemspath-context-object.json"
@@ -221,7 +221,7 @@ describe StateMachineLint do
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
   end
-    
+
   it 'should allow dynamic timeout fields in Task state' do
     j = File.read "test/task-with-dynamic-timeouts.json"
     linter = StateMachineLint::Linter.new
@@ -390,6 +390,13 @@ describe StateMachineLint do
   it 'should allow Choice Rule to use Comment' do
     j = File.read "test/choice-rule-with-comment.json"
     j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should allow a Comment field in Catcher' do
+    j = File.read "test/succeed-with-comment-in-catcher.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(0)

--- a/test/succeed-with-comment-in-catcher.json
+++ b/test/succeed-with-comment-in-catcher.json
@@ -1,0 +1,23 @@
+{
+  "Comment": "test",
+  "StartAt": "foo",
+  "States": {
+    "foo": {
+      "Type":"Task",
+      "Resource":"arn:aws:states:::lambda:invoke",
+      "Next": "end",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "foo",
+          "Next": "end"
+        }
+      ]
+    },
+    "end": {
+      "Type": "Fail"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allows `Comment` field in `Catch` statements.

![image](https://user-images.githubusercontent.com/25471619/172453280-09f7c26f-b5da-4a09-8241-4ac3128efc3f.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


For posterity's sake, I originally opened #48, but created a git mess.