### PR TITLE
Support ItemProcessor and ItemSelector in Map state

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -166,10 +166,18 @@ A Wait State MAY have a referencePath field named "TimestampPath".
 A Wait State MUST have only one of "Seconds", "SecondsPath", "Timestamp", and "TimestampPath".
 A Wait State MUST have a field named one of "Seconds", "SecondsPath", "Timestamp", or "TimestampPath".
 A Parallel State MUST have an object-array field named "Branches"; each element is a "Branch".
-A Map State MUST have an object field named "Iterator"; its value is a "Branch".
+A Map State MAY have an object field named "Iterator"; its value is a "ItemProcessor".
+A Map State MAY have an object field named "ItemProcessor"; its value is a "ItemProcessor".
+A Map State MUST have only one of "Iterator" and "ItemProcessor".
 A Map State MAY have a field named "ItemsPath".
+A Map State MAY have an object field named "ItemSelector".
+A Map State MAY have only one of "ItemSelector" and "Parameters".
 A Map State MAY have a numeric field named "MaxConcurrency".
 A Branch MUST have an object field named "States"; each field is a "State".
 A Branch MUST have a string field named "StartAt".
 A Branch MAY have a string field named "Comment".
 A Catcher MAY have a string field named "Comment".
+A ItemProcessor MAY have an object field named "ProcessorConfig".
+A ItemProcessor MAY have a string field named "Comment".
+A ItemProcessor MUST have a string field named "StartAt".
+A ItemProcessor MUST have an object field named "States"; each field is a "State".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -401,4 +401,18 @@ describe StateMachineLint do
     problems = linter.validate(j)
     expect(problems.size).to eq(0)
   end
+
+  it 'should allow ItemProcessor in Map' do
+    j = File.read("test/map-with-itemprocessor.json")
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should require ItemProcessor xor Iterator in Map' do
+    j = File.read("test/map-with-itemprocessor-and-iterator.json")
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+  end
 end

--- a/test/map-with-itemprocessor-and-iterator.json
+++ b/test/map-with-itemprocessor-and-iterator.json
@@ -1,0 +1,30 @@
+{
+  "StartAt": "m",
+  "States": {
+    "m": {
+      "Type": "Map",
+      "ItemProcessor":	{
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "y",
+        "States": {
+          "y": {
+            "Type": "Pass",
+            "End": true
+          }
+        }
+      },
+      "Iterator":	{
+        "StartAt": "x",
+        "States": {
+          "x": {
+            "Type": "Pass",
+            "End": true
+          }
+        }
+      },
+      "End": true
+    }
+  }
+}

--- a/test/map-with-itemprocessor.json
+++ b/test/map-with-itemprocessor.json
@@ -1,0 +1,21 @@
+{
+  "StartAt": "m",
+  "States": {
+    "m": {
+      "Type": "Map",
+      "ItemProcessor":	{
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "x",
+        "States": {
+          "x": {
+            "Type": "Pass",
+            "End": true
+          }
+        }
+      },
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
#59 
Iterator and Parameters are considered deprecated, but statelint flags the new fields as errors.

new inline map state fields: https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-inline.html#map-state-inline-additional-fields

*Description of changes:*
Add basic support for new fields so I can continue to use statelint :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
