### PR TITLE
Add additional test for Parameters and ItemSelector mutual exclusivity

### DIFF
--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -409,8 +409,15 @@ describe StateMachineLint do
     expect(problems.size).to eq(0)
   end
 
-  it 'should require ItemProcessor xor Iterator in Map' do
+  it 'should reject Map state with both Iterator and ItemProcessor' do
     j = File.read("test/map-with-itemprocessor-and-iterator.json")
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+  end
+
+  it 'should reject Map state with both Parameters and ItemSelector' do
+    j = File.read("test/map-with-parameters-and-itemselector.json")
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(1)

--- a/test/map-with-itemprocessor-and-iterator.json
+++ b/test/map-with-itemprocessor-and-iterator.json
@@ -3,7 +3,7 @@
   "States": {
     "m": {
       "Type": "Map",
-      "ItemProcessor":	{
+      "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "INLINE"
         },

--- a/test/map-with-itemprocessor.json
+++ b/test/map-with-itemprocessor.json
@@ -3,7 +3,7 @@
   "States": {
     "m": {
       "Type": "Map",
-      "ItemProcessor":	{
+      "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "INLINE"
         },

--- a/test/map-with-parameters-and-itemselector.json
+++ b/test/map-with-parameters-and-itemselector.json
@@ -1,0 +1,27 @@
+{
+    "StartAt": "m",
+    "States": {
+      "m": {
+        "Type": "Map",
+        "Parameters": {
+          "foo.$": "$.bar"
+        },
+        "ItemSelector": {
+          "foo.$": "$.bar"
+        },
+        "ItemProcessor": {
+          "ProcessorConfig": {
+            "Mode": "INLINE"
+          },
+          "StartAt": "x",
+          "States": {
+            "x": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        },
+        "End": true
+      }
+    }
+  }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/statelint/issues/59

*Description of changes:* Additional unit test coverage to assert Map does not permit `Parameters` and `ItemSelector` in the same Map state, which was added statelint in https://github.com/awslabs/statelint/pull/58

*Testing:* `bundle exec rspec`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
