### PR TITLE
add support for TaskCredentials

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -41,6 +41,7 @@ A Task State MAY have a referencePath field named "TimeoutSecondsPath".
 A Task State MAY have a referencePath field named "HeartbeatSecondsPath".
 A Task State MAY have only one of "TimeoutSeconds" and "TimeoutSecondsPath".
 A Task State MAY have only one of "HeartbeatSeconds" and "HeartbeatSecondsPath".
+A Task State MAY have an object field named "Credentials".
 A Retrier MUST have a nonempty-string-array field named "ErrorEquals".
 A Retrier MAY have an positive-integer field named "IntervalSeconds".
 A Retrier MAY have a nonnegative-integer field named "MaxAttempts" whose value MUST be less than 99999999.

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -422,4 +422,18 @@ describe StateMachineLint do
     problems = linter.validate(j)
     expect(problems.size).to eq(1)
   end
+
+  it 'should allow Credentials in Task' do
+    j = File.read "test/task-with-credentials.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should reject invalid Credentials in Task' do
+    j = File.read "test/task-with-invalid-credentials.json"
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+  end
 end

--- a/test/task-with-credentials.json
+++ b/test/task-with-credentials.json
@@ -1,0 +1,13 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "Credentials": {
+        "roleArn": "fizz:buzz"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/task-with-invalid-credentials.json
+++ b/test/task-with-invalid-credentials.json
@@ -1,0 +1,11 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "Credentials": "foo:bar",
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:*
Adds the description of TaskCredentials field to the state machine definition: [aws source docs
](https://docs.aws.amazon.com/step-functions/latest/apireference/API_TaskCredentials.html)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
