### PR TITLE
Change Retrier BackoffRate to be numeric instead of float

### DIFF
--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -45,7 +45,7 @@ A Task State MAY have an object field named "Credentials".
 A Retrier MUST have a nonempty-string-array field named "ErrorEquals".
 A Retrier MAY have an positive-integer field named "IntervalSeconds".
 A Retrier MAY have a nonnegative-integer field named "MaxAttempts" whose value MUST be less than 99999999.
-A Retrier MAY have a float field named "BackoffRate" whose value MUST be greater than or equal to 1.0.
+A Retrier MAY have a numeric field named "BackoffRate" whose value MUST be greater than or equal to 1.
 A Retrier MAY have a positive-integer field named "MaxDelaySeconds".
 A Retrier MAY have a string field named "JitterStrategy" whose value MUST be one of "FULL" or "NONE".
 Each of a Task State, a Parallel State, and a Map State MAY have an object-array field named "Catch"; each element is a "Catcher".

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -81,6 +81,40 @@ describe StateMachineLint do
     expect(problems[0]).to include('allowed floor is 0')
   end
 
+  it 'should allow BackOffRate integer' do
+    j = File.read "test/backoff-with-backoffrate-integer.json"
+    j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should allow BackOffRate decimal' do
+    j = File.read "test/backoff-with-backoffrate-decimal.json"
+    j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
+  it 'should reject BackOffRate negative' do
+    j = File.read "test/backoff-with-backoffrate-negative.json"
+    j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('allowed minimum is 1')
+  end
+
+  it 'should reject BackOffRate between 0 and 1' do
+    j = File.read "test/backoff-with-backoffrate-between-0-and-1.json"
+    j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(1)
+    expect(problems[0]).to include('allowed minimum is 1')
+  end
+
   it 'should reject empty ErrorEquals clauses' do
     j = File.read "test/empty-error-equals-on-catch.json"
     linter = StateMachineLint::Linter.new

--- a/test/backoff-with-backoffrate-between-0-and-1.json
+++ b/test/backoff-with-backoffrate-between-0-and-1.json
@@ -1,0 +1,16 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "End": true,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.Timeout"],
+          "BackoffRate": 0.3
+        }
+      ]
+    }
+  }
+}

--- a/test/backoff-with-backoffrate-decimal.json
+++ b/test/backoff-with-backoffrate-decimal.json
@@ -1,0 +1,16 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "End": true,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.Timeout"],
+          "BackoffRate": 2.42
+        }
+      ]
+    }
+  }
+}

--- a/test/backoff-with-backoffrate-integer.json
+++ b/test/backoff-with-backoffrate-integer.json
@@ -1,0 +1,16 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "End": true,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.Timeout"],
+          "BackoffRate": 3
+        }
+      ]
+    }
+  }
+}

--- a/test/backoff-with-backoffrate-negative.json
+++ b/test/backoff-with-backoffrate-negative.json
@@ -1,0 +1,16 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Task",
+      "Resource": "foo:bar",
+      "End": true,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.Timeout"],
+          "BackoffRate": -2
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/awslabs/statelint/issues/35

*Description of changes:* This PR changes the `BackoffRate` field within `Retrier` to be of type `numeric` (instead of `float`) to allow integer values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
