### PR TITLE
Bracket notation should accept paths with kebab case

### DIFF
--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -429,6 +429,14 @@ describe StateMachineLint do
     expect(problems.size).to eq(0)
   end
 
+  it 'should allow Choice Rule Variable to use kebab-case JSON Path' do
+    j = File.read "test/choice-rule-with-kebab-case-json-path.json"
+    j = JSON.parse j
+    linter = StateMachineLint::Linter.new
+    problems = linter.validate(j)
+    expect(problems.size).to eq(0)
+  end
+
   it 'should allow a Comment field in Catcher' do
     j = File.read "test/succeed-with-comment-in-catcher.json"
     linter = StateMachineLint::Linter.new

--- a/test/choice-rule-with-kebab-case-json-path.json
+++ b/test/choice-rule-with-kebab-case-json-path.json
@@ -1,0 +1,18 @@
+{
+  "StartAt": "p",
+  "States": {
+    "p": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$['detail-type']",
+          "StringEquals": "x",
+          "Next": "x"
+        }
+      ]
+    },
+    "x": {
+      "Type": "Succeed"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bracket notation should accept paths with kebab case.
Requires https://github.com/awslabs/j2119/pull/7

![Screenshot 2025-05-15 at 11 14 54](https://github.com/user-attachments/assets/21c54a0a-1d94-48b9-8315-e6a599438677)
![Screenshot 2025-05-15 at 11 14 48](https://github.com/user-attachments/assets/11a4e6af-b50c-48c9-8c81-1dc70a0c4f47)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
